### PR TITLE
Option to load from json to let user persist data between runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,18 @@ your app (see image above).
   # or pass the same arg to `stop_tracking`
   ```
 
-  This does NOT persist the data between deployments (use Firestore for this, see
-  above). This may also lead to problems with concurrency if many users access the site
-  at the same time.
+  And load it with:
+
+  ```python
+  streamlit_analytics.track(load_from_json="path/to/file.json")
+  # or pass the same arg to `stop_tracking`
+  ```
+
+  You can also combine both args to persist data to a json file. Note that this 
+  file might get deleted when doing a fresh deploy on a cloud service. Use Firestore
+  instead for persistence, see above. Also note that `load_from_json` will fail silently
+  if the JSON file does not exist. Writing to JSON may lead to problems with concurrency 
+  if many users access the site at the same time.
 
 ## TODO
 

--- a/README.md
+++ b/README.md
@@ -91,12 +91,14 @@ your app (see image above).
   # or pass the same arg to `stop_tracking`
   ```
 
-  And load it with:
+  And load with:
 
   ```python
   streamlit_analytics.track(load_from_json="path/to/file.json")
   # or pass the same arg to `stop_tracking`
   ```
+
+  (Thanks to @Uranium2 for implementing loading!)
 
   You can also combine both args to persist data to a json file. Note that this 
   file might get deleted when doing a fresh deploy on a cloud service. Use Firestore

--- a/streamlit_analytics/main.py
+++ b/streamlit_analytics/main.py
@@ -256,15 +256,21 @@ def start_tracking(
             print()
 
     if load_from_json is not None:
-        with Path(load_from_json).open("r") as f:
-            json_counts = json.load(f)
-            for key in json_counts:
-                if key in counts:
-                    counts[key] = json_counts[key]
         if verbose:
-            print(f"Loaded count data from json ({load_from_json}):")
-            print(counts)
-            print()
+            print(f"Loading counts from json:", load_from_json)
+        try:
+            with Path(load_from_json).open("r") as f:
+                json_counts = json.load(f)
+                for key in json_counts:
+                    if key in counts:
+                        counts[key] = json_counts[key]
+            if verbose:
+                print("Success! Loaded counts:")
+                print(counts)
+                print()
+        except FileNotFoundError as e:
+            if verbose:
+                print(f"File not found, proceeding with empty counts.")
 
     sess = get_session_state(
         user_tracked=False,

--- a/streamlit_analytics/main.py
+++ b/streamlit_analytics/main.py
@@ -236,6 +236,7 @@ def start_tracking(
     verbose: bool = False,
     firestore_key_file: str = None,
     firestore_collection_name: str = "counts",
+    load_from_json: Union[str, Path] = None,
 ):
     """
     Start tracking user inputs to a streamlit app.
@@ -251,6 +252,17 @@ def start_tracking(
         counts["loaded_from_firestore"] = True
         if verbose:
             print("Loaded count data from firestore:")
+            print(counts)
+            print()
+    
+    if load_from_json is not None:
+        with Path(load_from_json).open("r") as f:
+            json_counts = json.load(f)
+            for key in json_counts:
+                if key in counts:
+                    counts[key] = json_counts[key]
+        if verbose:
+            print(f"Loaded count data from json ({load_from_json}):")
             print(counts)
             print()
 
@@ -399,6 +411,7 @@ def stop_tracking(
 def track(
     unsafe_password: str = None,
     save_to_json: Union[str, Path] = None,
+    load_from_json: Union[str, Path] = None,
     firestore_key_file: str = None,
     firestore_collection_name: str = "counts",
     verbose=False,
@@ -410,11 +423,21 @@ def track(
     This also shows the analytics results below your app if you attach 
     `?analytics=on` to the URL.
     """
-    start_tracking(
-        verbose=verbose,
-        firestore_key_file=firestore_key_file,
-        firestore_collection_name=firestore_collection_name,
-    )
+
+    if load_from_json is not None:
+        start_tracking(
+            verbose=verbose,
+            firestore_key_file=firestore_key_file,
+            firestore_collection_name=firestore_collection_name,
+            load_from_json=load_from_json,
+        )
+    else:
+        start_tracking(
+            verbose=verbose,
+            firestore_key_file=firestore_key_file,
+            firestore_collection_name=firestore_collection_name,
+        )
+
     # Yield here to execute the code in the with statement. This will call the wrappers
     # above, which track all inputs.
     yield

--- a/streamlit_analytics/main.py
+++ b/streamlit_analytics/main.py
@@ -413,10 +413,10 @@ def stop_tracking(
 def track(
     unsafe_password: str = None,
     save_to_json: Union[str, Path] = None,
-    load_from_json: Union[str, Path] = None,
     firestore_key_file: str = None,
     firestore_collection_name: str = "counts",
     verbose=False,
+    load_from_json: Union[str, Path] = None,
 ):
     """
     Context manager to start and stop tracking user inputs to a streamlit app.

--- a/streamlit_analytics/main.py
+++ b/streamlit_analytics/main.py
@@ -178,7 +178,7 @@ def _wrap_select(func, state_dict):
 
 def _wrap_multiselect(func, state_dict):
     """
-    Wrap a streamlit function that returns multiple selected elements out of multiple 
+    Wrap a streamlit function that returns multiple selected elements out of multiple
     options, e.g. st.multiselect.
     """
 
@@ -204,7 +204,7 @@ def _wrap_multiselect(func, state_dict):
 def _wrap_value(func, state_dict):
     """
     Wrap a streamlit function that returns a single value (str/int/float/datetime/...),
-    e.g. st.slider, st.text_input, st.number_input, st.text_area, st.date_input, 
+    e.g. st.slider, st.text_input, st.number_input, st.text_area, st.date_input,
     st.time_input, st.color_picker.
     """
 
@@ -240,11 +240,11 @@ def start_tracking(
 ):
     """
     Start tracking user inputs to a streamlit app.
-    
-    If you call this function directly, you NEED to call 
+
+    If you call this function directly, you NEED to call
     `streamlit_analytics.stop_tracking()` at the end of your streamlit script.
-    For a more convenient interface, wrap your streamlit calls in 
-    `with streamlit_analytics.track():`. 
+    For a more convenient interface, wrap your streamlit calls in
+    `with streamlit_analytics.track():`.
     """
 
     if firestore_key_file and not counts["loaded_from_firestore"]:
@@ -254,7 +254,7 @@ def start_tracking(
             print("Loaded count data from firestore:")
             print(counts)
             print()
-    
+
     if load_from_json is not None:
         with Path(load_from_json).open("r") as f:
             json_counts = json.load(f)
@@ -267,7 +267,9 @@ def start_tracking(
             print()
 
     sess = get_session_state(
-        user_tracked=False, state_dict={}, last_time=datetime.datetime.now(),
+        user_tracked=False,
+        state_dict={},
+        last_time=datetime.datetime.now(),
     )
     _track_user(sess)
 
@@ -339,7 +341,7 @@ def stop_tracking(
 ):
     """
     Stop tracking user inputs to a streamlit app.
-    
+
     Should be called after `streamlit-analytics.start_tracking()`. This method also
     shows the analytics results below your app if you attach `?analytics=on` to the URL.
     """
@@ -418,9 +420,9 @@ def track(
 ):
     """
     Context manager to start and stop tracking user inputs to a streamlit app.
-    
-    To use this, wrap all calls to streamlit in `with streamlit_analytics.track():`. 
-    This also shows the analytics results below your app if you attach 
+
+    To use this, wrap all calls to streamlit in `with streamlit_analytics.track():`.
+    This also shows the analytics results below your app if you attach
     `?analytics=on` to the URL.
     """
 
@@ -448,4 +450,3 @@ def track(
         firestore_collection_name=firestore_collection_name,
         verbose=verbose,
     )
-

--- a/streamlit_analytics/main.py
+++ b/streamlit_analytics/main.py
@@ -426,19 +426,12 @@ def track(
     `?analytics=on` to the URL.
     """
 
-    if load_from_json is not None:
-        start_tracking(
-            verbose=verbose,
-            firestore_key_file=firestore_key_file,
-            firestore_collection_name=firestore_collection_name,
-            load_from_json=load_from_json,
-        )
-    else:
-        start_tracking(
-            verbose=verbose,
-            firestore_key_file=firestore_key_file,
-            firestore_collection_name=firestore_collection_name,
-        )
+    start_tracking(
+        verbose=verbose,
+        firestore_key_file=firestore_key_file,
+        firestore_collection_name=firestore_collection_name,
+        load_from_json=load_from_json,
+    )
 
     # Yield here to execute the code in the with statement. This will call the wrappers
     # above, which track all inputs.


### PR DESCRIPTION
Adding data persistence from Json file.

Loads json file and copy data into `counts` just like `firestone.load()`.

Added `load_from_json` argument in `track()` and `start_tracking()`. 

`start_tracking()` will load firebase AND/OR Json data. You can load, one, both or none.

`Black` the code to respect PEP 8 coding style.