### PR TITLE
Fixing parameter name `firestore_key_file` and `firestore_collection_name` at README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ your app (see image above).
   and pass the key file and collection name:
 
   ```python
-  streamlit_analytics.track(firebase_key_file="firebase-key.json", firebase_collection_name="counts")
+  streamlit_analytics.track(firestore_key_file="firebase-key.json", firestore_collection_name="counts")
   # or pass the same args to `start_tracking` AND `stop_tracking`
   ```
 


### PR DESCRIPTION
Following the README.md file to sync the `streamlit-analytics` to my Firestore account I've tried to access the `firebase_key_file` and `firebase_collection_name` as shown on the docs. Both of them raised unexpected keyword argument errors, so checking the code for `track()`, `start_tracking()` and `stop_tracking()` functions, I realized that the keywords expected were `firestore_key_file` and `firestore_ collection_name`. 

This PR merely changes the keyword arguments on the documentation. 