### PR TITLE
Fixing ctx call for version >1.4

### DIFF
--- a/streamlit_analytics/session_state.py
+++ b/streamlit_analytics/session_state.py
@@ -24,7 +24,11 @@ try:
     from streamlit.server.Server import Server
 except Exception:
     # Streamlit >= 0.65.0
-    import streamlit.report_thread as ReportThread
+    try: # Fix for Streamlit >= 1.4
+        import streamlit.report_thread as ReportThread
+    except Exception:
+        from streamlit.script_run_context import get_script_run_ctx
+    
     from streamlit.server.server import Server
 
 
@@ -70,9 +74,11 @@ def get(**kwargs):
     'Mary'
     """
     # Hack to get the session object from Streamlit.
-
-    ctx = ReportThread.get_report_ctx()
-
+    try:
+        ctx = ReportThread.get_report_ctx()
+    except Exception: # Fix for streamlit >= 1.4
+        ctx = get_script_run_ctx()
+        
     this_session = None
 
     current_server = Server.get_current()


### PR DESCRIPTION
ReportThread was removed in version 1.4, therefore it is now necessary to use get_script_run_ctx()
( see https://github.com/streamlit/streamlit/issues/4099 )