### PR TITLE
Fix ImportError with Streamlit >= 1.4.0

### DIFF
--- a/streamlit_analytics/session_state.py
+++ b/streamlit_analytics/session_state.py
@@ -22,10 +22,15 @@ result:
 try:
     import streamlit.ReportThread as ReportThread
     from streamlit.server.Server import Server
-except Exception:
-    # Streamlit >= 0.65.0
-    import streamlit.report_thread as ReportThread
+    get_script_run_ctx = ReportThread.get_report_ctx
+except ImportError:  # Streamlit >= 0.65.0
     from streamlit.server.server import Server
+
+    try:
+        import streamlit.report_thread as ReportThread
+        get_script_run_ctx = ReportThread.get_report_ctx
+    except ImportError:  # Streamlit >= 1.4.0
+        from streamlit.script_run_context import get_script_run_ctx
 
 
 class SessionState(object):
@@ -71,7 +76,7 @@ def get(**kwargs):
     """
     # Hack to get the session object from Streamlit.
 
-    ctx = ReportThread.get_report_ctx()
+    ctx = get_script_run_ctx()
 
     this_session = None
 


### PR DESCRIPTION
Fixes #14.

I only noticed that there's already a PR for this (#12) after fixing it locally, but I figured it's worth pushing anyway since this solution only catches `ImportError`s and isolates the try-except to the import section of the file.