### PR TITLE
session_state.py fix for streamlit >=1.8

### DIFF
--- a/streamlit_analytics/session_state.py
+++ b/streamlit_analytics/session_state.py
@@ -100,16 +100,24 @@ def get(**kwargs):
             (hasattr(s, "_main_dg") and s._main_dg == ctx.main_dg)
             or
             # Streamlit >= 0.54.0
-            (not hasattr(s, "_main_dg") and hasattr(s, "enqueue") and s.enqueue == ctx.enqueue)
+            (
+                not hasattr(s, "_main_dg")
+                and hasattr(s, "enqueue")
+                and s.enqueue == ctx.enqueue
+            )
             or
             # Streamlit >= 0.65.2
-            (not hasattr(s, "_main_dg") and s._uploaded_file_mgr == ctx.uploaded_file_mgr)
+            (
+                not hasattr(s, "_main_dg")
+                and s._uploaded_file_mgr == ctx.uploaded_file_mgr
+            )
         ):
             this_session = s
 
     if this_session is None:
         raise RuntimeError(
-            "Oh noes. Couldn't get your Streamlit Session object. " "Are you doing something fancy with threads?"
+            "Oh noes. Couldn't get your Streamlit Session object. "
+            "Are you doing something fancy with threads?"
         )
 
     # Got the session object! Now let's attach some state into it.


### PR DESCRIPTION
session_state.py edits that seek to unify the various changes from streamlit 0.65 up to 1.8.1. Incorporates version parsing directly to reduce reliance on try / except blocks.