### PR TITLE
 Fix traffic count initialization, bug in date parsing by altair @mateusccoelho

### DIFF
--- a/streamlit_analytics/display.py
+++ b/streamlit_analytics/display.py
@@ -60,7 +60,10 @@ def show_results(counts, reset_callback, unsafe_password=None):
             alt.themes.enable("streamlit")
         except:
             pass  # probably old Streamlit version
+
         df = pd.DataFrame(counts["per_day"])
+        df["days"] = df["days"] + "T00:00:00"
+        
         base = alt.Chart(df).encode(
             x=alt.X("monthdate(days):O", axis=alt.Axis(title="", grid=True))
         )

--- a/streamlit_analytics/display.py
+++ b/streamlit_analytics/display.py
@@ -62,8 +62,9 @@ def show_results(counts, reset_callback, unsafe_password=None):
             pass  # probably old Streamlit version
 
         df = pd.DataFrame(counts["per_day"])
+        # Formatting date by ISO-8601 to fix altair's date parsing bug 
         df["days"] = df["days"] + "T00:00:00"
-        
+
         base = alt.Chart(df).encode(
             x=alt.X("monthdate(days):O", axis=alt.Axis(title="", grid=True))
         )

--- a/streamlit_analytics/main.py
+++ b/streamlit_analytics/main.py
@@ -20,11 +20,11 @@ counts = {"loaded_from_firestore": False}
 
 def reset_counts():
     # Use yesterday as first entry to make chart look better.
-    yesterday = str(datetime.date.today() - datetime.timedelta(days=1))
+    today = datetime.date.today()
     counts["total_pageviews"] = 0
     counts["total_script_runs"] = 0
     counts["total_time_seconds"] = 0
-    counts["per_day"] = {"days": [str(yesterday)], "pageviews": [0], "script_runs": [0]}
+    counts["per_day"] = {"days": [str(today)], "pageviews": [0], "script_runs": [0]}
     counts["widgets"] = {}
     counts["start_time"] = datetime.datetime.now().strftime("%d %b %Y, %H:%M:%S")
 


### PR DESCRIPTION
This PR fix the problems of the issue #35.

1. Initializes traffic counts with the current day.
2. Format string by ISO-8601 standard to fix altair/javascript date parsing bug. This is a problem for negative timezones.